### PR TITLE
Add BoifunCam app profile and detect battery-capable doorbells

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The account profile must match the app used to register the account:
 - CloudPlus / CloudHome
 - ANRAN
 - Arenti
+- BoifunCam
 - ieGeek
 
 These apps use the same underlying Meari platform, but the server requires
@@ -215,6 +216,11 @@ while the camera is asleep:
 
 This is the difference between Frigate "just working" with these cameras
 and Frigate being effectively unusable with them.
+
+Some Meari doorbells are reported by the API as `doorbell` / `pictureDoorBell`
+rather than `snap`, even though their capability map advertises `bat`. The
+coordinator treats those battery-capable doorbell categories as battery
+cameras so they use the same wake/idle-stream lifecycle.
 
 ### Stream Host Mode
 

--- a/custom_components/cloudplus/api.py
+++ b/custom_components/cloudplus/api.py
@@ -83,6 +83,14 @@ APP_PROFILE_CONFIG: dict[str, AppProfileConfig] = {
         "84",
         encrypted_login=True,
     ),
+    "boifun": AppProfileConfig(
+        "104",
+        "6.2.0",
+        "1039",
+        REDIRECT_URL,
+        "104",
+        encrypted_login=True,
+    ),
     "iegeek": AppProfileConfig("81", "5.5.2", "552", REDIRECT_URL, "81"),
     "arenti": AppProfileConfig(
         "39",

--- a/custom_components/cloudplus/const.py
+++ b/custom_components/cloudplus/const.py
@@ -22,6 +22,7 @@ DEFAULT_APP_PROFILE = "cloudedge"
 APP_PROFILE_NAMES = {
     "cloudedge": "CloudEdge",
     "anran": "ANRAN",
+    "boifun": "BoifunCam",
     "cloudplus": "CloudPlus / CloudHome",
     "iegeek": "ieGeek",
     "arenti": "Arenti",

--- a/custom_components/cloudplus/coordinator/__init__.py
+++ b/custom_components/cloudplus/coordinator/__init__.py
@@ -104,8 +104,12 @@ class CloudEdgeMeariCoordinator(CoordinatorStateMixin):
         self._sn_num = str(device.get("snNum", ""))
         self._device_name = str(device.get("deviceName", self._sn_num) or self._sn_num)
         self._device_category = str(device.get("_category", "")).lower()
-        self._is_snap = self._device_category == "snap"
         self._capabilities = parse_capabilities(device)
+        battery_capable_doorbell = (
+            self._device_category in {"doorbell", "picturedoorbell", "voicebell"}
+            and (self._as_int(self._capabilities.get("bat")) or 0) > 0
+        )
+        self._is_snap = self._device_category == "snap" or battery_capable_doorbell
         self._iot_data: dict[int | str, Any] = {}
 
         self._available = False

--- a/debug_tools/common.py
+++ b/debug_tools/common.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-AUTH_PROFILES = ("cloudedge", "anran", "cloudplus", "iegeek", "arenti")
+AUTH_PROFILES = ("cloudedge", "anran", "boifun", "cloudplus", "iegeek", "arenti")
 AUTH_DEFAULTS = {
     "country_code": "FR",
     "phone_code": "33",

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -1,8 +1,8 @@
 # Protocol Reference
 
 Wire-level notes for the Meari / VVP / PPStrong stack used by CloudEdge,
-CloudPlus, Meari, ANRAN, ieGeek and Arenti battery cameras. These are the load-bearing
-facts the integration relies on — change them at your peril.
+CloudPlus, Meari, ANRAN, ieGeek, Arenti and BoifunCam battery cameras. These
+are the load-bearing facts the integration relies on — change them at your peril.
 
 For control-flow patterns built on top of these primitives (live-start
 ordering, source-idle recovery, wake retries) see [streaming.md](streaming.md).
@@ -20,6 +20,7 @@ ordering, source-idle recovery, wake retries) see [streaming.md](streaming.md).
   - `cloudplus` → CloudPlus / CloudHome app/API, VVP stream flag `1`
   - `iegeek` → ieGeek app identity, VVP stream flag `1`
   - `arenti` → Arenti app/API host family, VVP stream flag `1`
+  - `boifun` → BoifunCam app identity, VVP stream flag `1`
 - Each profile supplies the official app's `sourceApp`, `partnerId`, version
   and version code. These values are part of login account encryption and are
   not interchangeable between branded apps.
@@ -187,7 +188,7 @@ ordering, source-idle recovery, wake retries) see [streaming.md](streaming.md).
   - `0x888e` — heartbeat
 - Modern `START_LIVE` uses parameter `8`, the camera host key, a formatted
   licence ID, a stream id, and the app-profile stream flag (`0` CloudEdge /
-  `1` ANRAN, CloudPlus, ieGeek and Arenti; see
+  `1` ANRAN, CloudPlus, ieGeek, Arenti and BoifunCam; see
   [Discovery](#discovery-and-http-api)). Legacy PPCS authenticates with the
   first 16 host-key bytes and omits the licence component, matching the native
   packet exactly.


### PR DESCRIPTION
## Summary

Adds support for the **BoifunCam** app using the internal app profile identifier `boifun`, and improves battery-camera detection for doorbell-class devices that advertise the `bat` capability rather than being returned with the `snap` category.

## BoifunCam profile

Adds the BoifunCam app profile with:

- source app: `104`
- partner ID: `104`
- app version: `6.2.0`
- app version code: `1039`
- encrypted login enabled
- VVP stream flag: `1`

The profile is available in both the Home Assistant config flow and the standalone debug harness.

## Battery doorbell detection

The tested BoifunCam device is returned with category `doorbell`, rather than `snap`, but advertises `bat=1`.

Previously this meant it was treated as a continuously powered IPC camera and the battery-camera lifecycle was not enabled.

This change treats known doorbell categories advertising the `bat` capability as battery cameras, while retaining the existing `snap` behavior.

This enables the existing battery-camera features including:

- camera entity enabled by default
- idle/live stream switching
- camera wake support
- battery-camera streaming lifecycle

## Hardware validation

Tested with a BoifunCam battery doorbell reporting firmware platform:
`firmware-B411B-m_general-6.1.3.20250718`

Available at [Amazon.com.au](https://www.amazon.com.au/dp/B0FK4K5CY9).

Validated:

- account login and device discovery in the AU region
- Home Assistant integration setup
- camera idle/live switching
- manual camera wake
- SD stream ID `100`: 640×360 H.264
- QHD stream ID `102`: 2304×1296 H.264
- G.711 μ-law audio
- TURN media path
- direct/LAN P2P media path
- motion MQTT events

## Validation

Tested using:

```
python debug.py list
python debug.py --debug stream --device-id <device-id> --duration 30 --quality SD
python debug.py --debug stream --device-id <device-id> --duration 30 --quality QHD
```

Also successfully tested in Home Assistant 2026.7.2.