### PR TITLE
Use motion-event snapshots for camera still images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ means the doc is broken — fix it now, not later.
 
 A Home Assistant custom integration for Meari-family battery cameras
 (CloudEdge / CloudPlus / Meari / ieGeek / Arenti). Pure asyncio, no build
-step, no test suite, runtime is HA. Validate with [debug.py](debug.py).
+step, runtime is HA. Offline motion snapshot regression tests live in `tests/`. Validate with [debug.py](debug.py).
 
 ## Repo map
 
@@ -51,7 +51,8 @@ pip install pylint   # linter (dev only)
 
 ## Iteration loop
 
-No tests. Validate every behaviour change with the harness:
+Run `python -m unittest discover -s tests -v` for offline motion snapshot
+regression coverage. Validate hardware behaviour changes with the harness:
 
 ```bash
 python debug.py list                                              # auth + discovery

--- a/custom_components/cloudplus/camera.py
+++ b/custom_components/cloudplus/camera.py
@@ -82,4 +82,7 @@ class CloudEdgeMeariCamera(CloudEdgeMeariEntity, Camera):
         if self._coordinator.device_id:
             attrs["device_id"] = self._coordinator.device_id
         attrs["sn_num"] = self._coordinator.device_uuid
+        attrs["image_source"] = self._coordinator.latest_image_source
+        attrs["image_generation"] = self._coordinator.latest_image_generation
+        attrs["image_updated_at"] = self._coordinator.latest_image_updated_at
         return attrs

--- a/custom_components/cloudplus/coordinator/__init__.py
+++ b/custom_components/cloudplus/coordinator/__init__.py
@@ -115,6 +115,9 @@ class CloudEdgeMeariCoordinator(CoordinatorStateMixin):
         self._available = False
         self._camera_awake = False
         self._latest_image: bytes | None = None
+        self._latest_image_source = ""
+        self._latest_image_generation = 0
+        self._latest_image_updated_at = 0.0
         self._latest_video_kf: bytes | None = None
         self._snapshot_conversion_enabled = bool(snapshot_conversion_enabled)
         self._snapshot_convert_interval = max(1.0, float(snapshot_min_interval))
@@ -531,6 +534,9 @@ class CloudEdgeMeariCoordinator(CoordinatorStateMixin):
                 self._idle_video_frame = None
                 self._latest_video_kf = None
             self._latest_image = None
+            self._latest_image_source = ""
+            self._latest_image_generation += 1
+            self._latest_image_updated_at = 0.0
         self._fire_update()
 
     def _idle_loop(self) -> None:
@@ -689,6 +695,8 @@ class CloudEdgeMeariCoordinator(CoordinatorStateMixin):
     def _maybe_convert_snapshot(self, codec: str, payload: bytes) -> None:
         if not self._snapshot_conversion_enabled or not payload:
             return
+        if self._motion_detected and self._latest_image_source == "event":
+            return
         now = time.monotonic()
         interval = self._snapshot_convert_interval
         if now <= self._snapshot_requested_until:
@@ -713,8 +721,14 @@ class CloudEdgeMeariCoordinator(CoordinatorStateMixin):
     def _convert_snapshot(self, codec: str, payload: bytes) -> None:
         try:
             jpeg = self._video_to_jpeg(codec, payload)
-            if jpeg:
+            # An event may arrive while ffmpeg is converting an older frame.
+            if jpeg and not (
+                self._motion_detected and self._latest_image_source == "event"
+            ):
                 self._latest_image = jpeg
+                self._latest_image_source = "live"
+                self._latest_image_generation += 1
+                self._latest_image_updated_at = time.time()
                 self._fire_update()
         finally:
             self._snapshot_convert_lock.release()

--- a/custom_components/cloudplus/coordinator/motion.py
+++ b/custom_components/cloudplus/coordinator/motion.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import ssl
 import threading
 import time
-from typing import Callable
+from typing import Any, Callable
 
 import paho.mqtt.client as mqtt
 
@@ -19,6 +20,55 @@ ALARM_POLL_INTERVAL = 15.0
 ALARM_POLL_ERROR_INTERVAL = 60.0
 # Cap on remembered event ids so the dedup set can't grow without bound.
 _SEEN_ALARM_CAP = 4000
+_IMAGE_URL_KEYS = (
+    "imageUrl",
+    "imageURL",
+    "picUrl",
+    "picURL",
+    "thumbUrl",
+    "snapshotUrl",
+)
+
+
+def _find_image_url(raw_event: dict[str, Any]) -> str:
+    """Return the first event snapshot URL found in a nested payload."""
+    queue: list[Any] = [raw_event]
+    seen: set[int] = set()
+    while queue:
+        item = queue.pop(0)
+        if isinstance(item, dict):
+            if id(item) in seen:
+                continue
+            seen.add(id(item))
+            for key in _IMAGE_URL_KEYS:
+                value = item.get(key)
+                if isinstance(value, str) and value.startswith(
+                    ("http://", "https://")
+                ):
+                    return value
+            queue.extend(item.values())
+        elif isinstance(item, list):
+            queue.extend(item)
+    return ""
+
+
+def _decode_event_snapshot(data: bytes, sn_num: str) -> bytes | None:
+    """Decode Meari event JPEG obfuscation for the owning camera."""
+    if data.startswith(b"\xff\xd8\xff"):
+        return data
+    if not data or not sn_num:
+        return None
+
+    key_material = f"{sn_num}|{len(sn_num)}|meari.stream".encode()
+    key = hashlib.md5(key_material, usedforsecurity=False).hexdigest().encode()  # noqa: S324
+    encrypted_size = min(1024, len(data))
+    decoded = bytes(
+        value ^ key[index % len(key)]
+        for index, value in enumerate(data[:encrypted_size])
+    ) + data[encrypted_size:]
+    if not decoded.startswith(b"\xff\xd8\xff"):
+        return None
+    return decoded
 
 
 def _mqtt_callback_code(args: tuple) -> object:
@@ -64,7 +114,9 @@ class MotionEventListener:
     def __init__(self, api: MeariApiClient) -> None:
         self._api = api
         self._client = None
-        self._callbacks: list[tuple[str, str, Callable[[str], None]]] = []
+        self._callbacks: list[
+            tuple[str, str, Callable[[str, bytes | None], None]]
+        ] = []
         self._lock = threading.Lock()
         self._stop_poll = threading.Event()
         self._poll_thread: threading.Thread | None = None
@@ -81,7 +133,7 @@ class MotionEventListener:
         self,
         device_id: int,
         sn_num: str,
-        on_motion: Callable[[str], None],
+        on_motion: Callable[[str, bytes | None], None],
     ) -> Callable[[], None]:
         item = (str(device_id), str(sn_num), on_motion)
         with self._lock:
@@ -333,15 +385,15 @@ class MotionEventListener:
 
     def _matching_callbacks(
         self, device_id: str, license_id: str
-    ) -> list[Callable[[str], None]]:
+    ) -> list[tuple[str, Callable[[str, bytes | None], None]]]:
         with self._lock:
             callbacks = list(self._callbacks)
-        out: list[Callable[[str], None]] = []
+        out: list[tuple[str, Callable[[str, bytes | None], None]]] = []
         for registered_device_id, registered_sn, callback in callbacks:
             if device_id and device_id == registered_device_id:
-                out.append(callback)
+                out.append((registered_sn, callback))
             elif not device_id and license_id and license_id == registered_sn:
-                out.append(callback)
+                out.append((registered_sn, callback))
         return out
 
     def _handle_payload(self, payload: bytes) -> None:
@@ -359,5 +411,15 @@ class MotionEventListener:
             return
 
         motion_type = str(event["evt_name"])
-        for callback in self._matching_callbacks(device_id, license_id):
-            callback(motion_type)
+        raw_event = event["raw"]
+        image_url = _find_image_url(raw_event)
+        encrypted_image = (
+            self._api.download_snapshot(image_url) if image_url else None
+        )
+        for sn_num, callback in self._matching_callbacks(device_id, license_id):
+            event_image = (
+                _decode_event_snapshot(encrypted_image, sn_num)
+                if encrypted_image
+                else None
+            )
+            callback(motion_type, event_image)

--- a/custom_components/cloudplus/coordinator/state.py
+++ b/custom_components/cloudplus/coordinator/state.py
@@ -27,6 +27,10 @@ _LOGGER = logging.getLogger(__name__)
 class CoordinatorStateMixin:
     """Mixin exposing availability and IoT-derived state to HA entities."""
 
+    _latest_image_source: str
+    _latest_image_generation: int = 0
+    _latest_image_updated_at: float
+
     @property
     def available(self) -> bool:
         return self._available
@@ -34,6 +38,18 @@ class CoordinatorStateMixin:
     @property
     def latest_image(self) -> bytes | None:
         return self._latest_image
+
+    @property
+    def latest_image_source(self) -> str:
+        return self._latest_image_source
+
+    @property
+    def latest_image_generation(self) -> int:
+        return self._latest_image_generation
+
+    @property
+    def latest_image_updated_at(self) -> float:
+        return self._latest_image_updated_at
 
     @property
     def motion_type(self) -> str:
@@ -284,7 +300,16 @@ class CoordinatorStateMixin:
         duration = float(seconds if seconds is not None else self._motion_timeout)
         self._live_deadline = max(self._live_deadline, time.monotonic() + duration)
 
-    def _note_motion(self, motion_type: str) -> None:
+    def _note_motion(self, motion_type: str, event_image: bytes | None = None) -> None:
+        if event_image:
+            self._latest_image = event_image
+            self._latest_image_source = "event"
+            self._latest_image_generation += 1
+            self._latest_image_updated_at = time.time()
+            # Keep the exact alarm image authoritative while motion is active.
+            # A wake-up may first replay an old keyframe from the previous session.
+            self._last_snapshot_convert_time = time.monotonic()
+            self._fire_update()
         self._last_motion_time = time.monotonic()
         self._set_motion(True, motion_type)
         if self._is_snap and self._motion_wake_enabled:

--- a/docs/motion-events.md
+++ b/docs/motion-events.md
@@ -139,3 +139,53 @@ motion delivery permanently stopped until Home Assistant restarts.
 - Alarm types observed in the wild but not currently in `MOTION_ALARM_TYPES`
   are intentionally non-motion (e.g. `21 SD card removed`, `10 Tamper`).
   Adding them to motion would create false positives.
+
+## Event snapshots
+
+When a motion payload (MQTT or the existing event-log poller) includes an
+HTTP(S) image URL, the listener downloads it using the existing bounded
+`download_snapshot` helper. It accepts ordinary JPEG data and the ieGeek/Meari
+`.jpgx3` obfuscation observed on battery cameras: XOR the first 1,024 bytes
+with the ASCII MD5 hex digest of `<serial>|<serial-length>|meari.stream`.
+The serial is taken from the matched camera registration. This is format
+decoding, not user-configured E2EE decryption; unknown formats are rejected
+by their JPEG signature. No serials, image URLs or image bytes are logged.
+
+The decoded image is installed in the camera cache before publishing motion.
+While motion is active, video still conversion does not replace an event
+image; this is checked both before starting conversion and when a conversion
+finishes. Live still conversion resumes after motion clears. This changes
+the cached still only, not the MPEG-TS live stream.
+
+Camera attributes expose:
+
+- `image_source`: `event`, `live`, or an empty string when no image is cached.
+- `image_generation`: an incrementing counter for image replacement or clearing.
+- `image_updated_at`: Unix time when the local cache received an image, or
+  zero when empty. This is **not the camera's capture timestamp** and does
+  not establish the age of a delayed cloud event.
+
+A missing URL, failed download or unsupported image still delivers the
+motion callback without a new image. This change adds no event-history
+queries, retry loop, authentication session, notifications or AI processing.
+It deliberately does not pair an image-less MQTT event with an arbitrary
+latest historical event; the regular poller can deliver an image-bearing
+event later. A download can delay motion delivery by the helper's timeout
+(currently ten seconds); offloading downloads would require a separate
+decision about motion/image ordering.
+
+### Offline regression checks
+
+Run from the repository root with Python 3.12+ and the standalone harness
+dependencies (`pycryptodome`, `paho-mqtt`, `requests`, `aiohttp`, `voluptuous`):
+
+```bash
+python -m unittest discover -s tests -v
+```
+
+These tests reuse `debug_tools.bootstrap`, load the actual parser, listener
+and coordinator methods, and mock only external services. They require no
+HA server, network calls, camera photos or account credentials. Synthetic
+protocol bytes exercise decoding and rejection, routing, startup seeding,
+event de-duplication, unavailable images and an in-flight still conversion.
+Live hardware and phone rendering still require an end-to-end test.

--- a/tests/test_motion_snapshots.py
+++ b/tests/test_motion_snapshots.py
@@ -1,0 +1,162 @@
+"""Offline regression tests using the existing standalone integration loader."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from debug_tools.bootstrap import _bootstrap_integration_modules
+
+MODULES = _bootstrap_integration_modules()
+MOTION = importlib.import_module("custom_components.cloudplus.coordinator.motion")
+COORDINATOR = MODULES["coordinator"].CloudEdgeMeariCoordinator
+# Synthetic protocol bytes; no camera captures, credentials or device identifiers.
+JPEG = b"\xff\xd8\xff" + bytes(range(256)) * 8
+SERIAL = "synthetic-camera"
+IMAGE_URL = "https://example.invalid/alarm.jpgx3"
+
+
+def obfuscate(data: bytes, serial: str = SERIAL) -> bytes:
+    """Build a synthetic Meari payload including its unchanged suffix."""
+    material = f"{serial}|{len(serial)}|meari.stream".encode()
+    key = hashlib.md5(material, usedforsecurity=False).hexdigest().encode()
+    return bytes(value ^ key[index % len(key)] for index, value in
+                 enumerate(data[:1024])) + data[1024:]
+
+
+class MotionSnapshotTests(unittest.TestCase):
+    """Exercise parsing, camera routing and backward-compatible failures."""
+
+    def setUp(self):
+        self.api = Mock()
+        self.api.download_snapshot.return_value = obfuscate(JPEG)
+        self.listener = MOTION.MotionEventListener(self.api)
+        self.received = Mock()
+        self.other = Mock()
+        self.listener.register(42, SERIAL, self.received)
+        self.listener.register(43, "other-camera", self.other)
+
+    def dispatch(self, **overrides):
+        event = {"deviceID": "42", "eventType": 2, "imageUrl": IMAGE_URL}
+        event.update(overrides)
+        self.listener._handle_payload(json.dumps({"params": event}).encode())
+
+    def test_plain_jpeg_is_unchanged(self):
+        self.assertEqual(MOTION._decode_event_snapshot(JPEG, SERIAL), JPEG)
+
+    def test_obfuscated_image_preserves_suffix(self):
+        self.assertEqual(MOTION._decode_event_snapshot(obfuscate(JPEG), SERIAL), JPEG)
+
+    def test_wrong_camera_and_invalid_data_are_rejected(self):
+        for data, serial in [(obfuscate(JPEG), "wrong-camera"),
+                             (b"", SERIAL), (b"invalid", SERIAL),
+                             (obfuscate(JPEG), "")]:
+            with self.subTest(serial=serial, size=len(data)):
+                self.assertIsNone(MOTION._decode_event_snapshot(data, serial))
+
+    def test_nested_url_and_invalid_scheme(self):
+        self.assertEqual(MOTION._find_image_url(
+            {"items": [{"data": {"picUrl": IMAGE_URL}}]}), IMAGE_URL)
+        self.assertEqual(MOTION._find_image_url({"imageUrl": "file:///tmp/a"}), "")
+
+    def test_event_photo_only_reaches_owning_camera(self):
+        self.dispatch()
+        self.received.assert_called_once_with("Motion", JPEG)
+        self.other.assert_not_called()
+
+    def test_serial_only_routing(self):
+        self.dispatch(deviceID="", licenseID=SERIAL)
+        self.received.assert_called_once_with("Motion", JPEG)
+        self.other.assert_not_called()
+
+    def test_missing_image_still_delivers_motion_without_extra_lookup(self):
+        self.dispatch(imageUrl="")
+        self.received.assert_called_once_with("Motion", None)
+        self.api.download_snapshot.assert_not_called()
+        self.api.get_device_events.assert_not_called()
+
+    def test_failed_download_still_delivers_motion(self):
+        self.api.download_snapshot.return_value = None
+        self.dispatch()
+        self.received.assert_called_once_with("Motion", None)
+
+    def test_invalid_image_still_delivers_motion(self):
+        self.api.download_snapshot.return_value = b"invalid"
+        self.dispatch()
+        self.received.assert_called_once_with("Motion", None)
+
+    def test_non_motion_does_not_download(self):
+        self.dispatch(eventType=21)
+        self.api.download_snapshot.assert_not_called()
+        self.received.assert_not_called()
+
+    def test_poll_startup_seeds_without_notifying_then_delivers_new_image(self):
+        old = {"deviceID": "42", "eventType": 2, "msgID": "old", "imageUrl": IMAGE_URL}
+        self.api.get_device_events.side_effect = lambda device, _day: [old] if device == "42" else []
+        self.api.get_new_device_events.return_value = []
+        self.listener._poll_device_events(dispatch=False)
+        self.received.assert_not_called()
+        self.api.download_snapshot.assert_not_called()
+        self.api.get_device_events.side_effect = (
+            lambda device, _day: [old, dict(old, msgID="new")] if device == "42" else []
+        )
+        self.listener._poll_device_events(dispatch=True)
+        self.listener._poll_device_events(dispatch=True)
+        self.received.assert_called_once_with("Motion", JPEG)
+
+
+class SnapshotCacheTests(unittest.TestCase):
+    """Check event publication order and a conversion already in progress."""
+
+    def setUp(self):
+        self.coord = SimpleNamespace(
+            _latest_image=None, _latest_image_source="", _latest_image_generation=0,
+            _latest_image_updated_at=0.0, _motion_detected=False, _is_snap=False,
+            _fire_update=Mock(), _set_motion=Mock(), _video_to_jpeg=Mock(return_value=JPEG),
+            _snapshot_convert_lock=threading.Lock(),
+        )
+
+    def test_event_image_is_available_when_motion_is_published(self):
+        def check_image(*_args):
+            self.assertEqual(self.coord._latest_image, JPEG)
+            self.assertEqual(self.coord._latest_image_source, "event")
+            self.assertGreater(self.coord._latest_image_updated_at, 0)
+        self.coord._set_motion.side_effect = check_image
+        COORDINATOR._note_motion(self.coord, "Motion", JPEG)
+        self.coord._set_motion.assert_called_once_with(True, "Motion")
+        self.assertEqual(self.coord._latest_image_generation, 1)
+
+    def test_missing_image_does_not_claim_new_freshness(self):
+        COORDINATOR._note_motion(self.coord, "Motion")
+        self.assertEqual(self.coord._latest_image_updated_at, 0)
+        self.assertEqual(self.coord._latest_image_source, "")
+        self.coord._set_motion.assert_called_once_with(True, "Motion")
+
+    def test_inflight_video_conversion_cannot_replace_active_event_image(self):
+        def convert(_codec, _payload):
+            COORDINATOR._note_motion(self.coord, "Motion", b"event-photo")
+            self.coord._motion_detected = True
+            return JPEG
+        self.coord._video_to_jpeg.side_effect = convert
+        self.coord._snapshot_convert_lock.acquire()
+        COORDINATOR._convert_snapshot(self.coord, "h264", b"frame")
+        self.assertEqual(self.coord._latest_image, b"event-photo")
+        self.assertEqual(self.coord._latest_image_source, "event")
+        self.assertFalse(self.coord._snapshot_convert_lock.locked())
+
+    def test_live_conversion_resumes_after_motion(self):
+        self.coord._latest_image_source = "event"
+        self.coord._snapshot_convert_lock.acquire()
+        COORDINATOR._convert_snapshot(self.coord, "h264", b"frame")
+        self.assertEqual(self.coord._latest_image, JPEG)
+        self.assertEqual(self.coord._latest_image_source, "live")
+        self.assertFalse(self.coord._snapshot_convert_lock.locked())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Use motion-event snapshots for camera still images

On ieGeek/Meari battery cameras, motion can arrive while `camera.snapshot` still returns a previous cached video frame. This change uses the JPEG attached to the event, when available, so an automation can save that image and inspect its cache source and update time.

The listener finds image URLs in nested MQTT and polled payloads, downloads them with the existing helper, and decodes plain JPEG or the observed Meari `.jpgx3` format using the matched camera's serial. The coordinator publishes the image before motion, preserves it during active motion, and exposes `image_source`, `image_generation` and `image_updated_at`. Missing or unsupported images keep motion delivery working without claiming a fresh image.

This changes cached still images, not the live stream. No household-specific entities, notification recipients, recognition rules, schedules, photos, credentials, runtime dependencies or version changes are included.

## Validation

- 15 offline regression tests using the repository's standalone loader and actual parser/listener/coordinator methods, with mocked cloud responses.
- Coverage: decoding, wrong-camera rejection, nested payloads, camera routing, absent/invalid images, startup seeding, polling de-duplication, image publication before motion, in-flight conversion protection and resuming live stills.
- Run: `python -m unittest discover -s tests -v`.
- A related local repair was loaded on Home Assistant Core 2026.9.0 with CloudPlus 0.3.1: configuration validation passed and image metadata returned. That variant has an additional history lookup, deliberately omitted here because picking the latest historical image does not reliably establish event identity.
- This exact reduced proposal has been tested offline, not deployed for a new physical camera-to-phone test. End-to-end rendering and other firmware variants remain to be verified.

## Tradeoffs for review

- Image download occurs before the motion callback in the listener thread and may delay delivery by the helper's current ten-second timeout. Background fetching is an alternative, but needs explicit image/motion ordering semantics.
- `image_updated_at` is local receipt/cache time, not device capture time; delayed footage must not be assumed to have been captured just now.
- The decoder checks the JPEG signature, not full JPEG validity, and is not a general E2EE decoder.
- No arbitrary latest-event lookup is added for image-less MQTT messages. The existing event-log poller remains the fallback source for image-bearing events.

Would this limited change fit the project's direction? I am happy to adapt the cache attributes or delivery strategy to the preferred interface.
